### PR TITLE
Fix TypeError in Qwen3TTSTokenizerV2DecoderTransformerModel forward()

### DIFF
--- a/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -512,7 +512,7 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs()
+    @check_model_inputs
     @auto_docstring
     def forward(
         self,


### PR DESCRIPTION
The error `TypeError: check_model_inputs() missing 1 required positional argument: 'func'` occurs because the `check_model_inputs` decorator from transformers.utils.generic is used incorrectly with empty parentheses `@check_model_inputs()`.

This decorator expects to receive the decorated function directly (without `()`), as it's a simple decorator, not a factory.

**Changes:**
- Removed `()` from `@check_model_inputs()` → `@check_model_inputs` in `modeling_qwen3_tts_tokenizer_v2.py`
- Fixed decorator usage on Qwen3TTSTokenizerV2DecoderTransformerModel.forward()

**Tested:** ComfyUI custom node now loads without import errors on Windows portable setup.

Closes #<issue-number-if-applies>