### PR TITLE
Add model download script and documentation [添加模型下载脚本和文档] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ ComfyUI custom nodes for speech synthesis, voice cloning, and voice design, base
 ## Nodes List
 
 ### 1. Qwen3-TTS Voice Design (`VoiceDesignNode`)
+
 Generate unique voices based on text descriptions.
+
 - **Inputs**:
   - `text`: Target text to synthesize.
   - `instruct`: Description of the voice (e.g., "A gentle female voice with a high pitch").
@@ -32,7 +34,9 @@ Generate unique voices based on text descriptions.
 - **Capabilities**: Best for creating "imaginary" voices or specific character archetypes.
 
 ### 2. Qwen3-TTS Voice Clone (`VoiceCloneNode`)
+
 Clone a voice from a reference audio clip.
+
 - **Inputs**:
   - `ref_audio`: A short (5-15s) audio clip to clone.
   - `ref_text`: Text spoken in the `ref_audio` (helps improve quality).
@@ -40,29 +44,69 @@ Clone a voice from a reference audio clip.
   - `model_choice`: Choose between **0.6B** (fast) or **1.7B** (high quality).
 
 ### 3. Qwen3-TTS Custom Voice (`CustomVoiceNode`)
+
 Standard TTS using preset speakers.
+
 - **Inputs**:
   - `text`: Target text.
   - `speaker`: Selection from preset voices (Aiden, Eric, Serena, etc.).
   - `instruct`: Optional style instructions.
 
 ### 4. Qwen3-TTS Voice Clone Prompt (`VoiceClonePromptNode`) [New]
+
 Extract and reuse voice features from reference audio.
+
 - **Capabilities**: Extract a "prompt item" once and use it multiple times across different `VoiceCloneNode` instances for faster and more consistent generation.
 
 ### 5. Qwen3-TTS Multi-role Dialogue (`DialogueInferenceNode`) [New]
-Synthesize complex dialogues with multiple speakers.
-- **Capabilities**: Handles multi-role speech synthesis in a single node, ideal for audiobook narration or roleplay scenarios.
 
+Synthesize complex dialogues with multiple speakers.
+
+- **Capabilities**: Handles multi-role speech synthesis in a single node, ideal for audiobook narration or roleplay scenarios.
 
 ## Installation
 
 Ensure you have the required dependencies:
+
 ```bash
 pip install torch torchaudio transformers librosa accelerate
 ```
 
+## Model Downloading (Offline Use)
+
+By default, the nodes will attempt to download models from Hugging Face automatically. For offline usage or to avoid download timeouts, you can manually download the models.
+
+### Option 1: Automatic Download Script (Recommended)
+
+You can simply run the provided python script to download all necessary models to the correct location:
+
+```bash
+python download_models.py
+```
+
+_Note: This script will try to detect your ComfyUI installation. You can also pass arguments like `--small` for 0.6B models._
+
+### Option 2: Manual Download
+
+1. Create a folder `qwen-tts` inside your ComfyUI `models` directory:
+
+   ```
+   ComfyUI/models/qwen-tts/
+   ```
+
+2. Download the models from Hugging Face and place them in subfolders. The folder names **must match exactly**:
+
+| Model Type               | Folder Name (Create this inside `qwen-tts`) | Hugging Face Repo                                                   |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------------------------- |
+| **Tokenizer** (Required) | `Qwen3-TTS-Tokenizer-12Hz`                  | [Link](https://huggingface.co/Qwen/Qwen3-TTS-Tokenizer-12Hz)        |
+| **Voice Clone** (Base)   | `Qwen3-TTS-12Hz-1.7B-Base`                  | [Link](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base)        |
+| **Voice Design**         | `Qwen3-TTS-12Hz-1.7B-VoiceDesign`           | [Link](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign) |
+| **Custom Voice**         | `Qwen3-TTS-12Hz-1.7B-CustomVoice`           | [Link](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice) |
+
+> **Note**: For the 0.6B versions, check the [Qwen3 Collection](https://huggingface.co/collections/Qwen/qwen3-tts).
+
 ## Tips for Best Results
+
 - **Cloning**: Use clean, noise-free reference audio (5-15 seconds).
 - **VRAM**: Use `bf16` precision to save significant memory with minimal quality loss.
 - **Local Models**: Pre-download weights to `models/qwen-tts/` to prioritize local loading and avoid HuggingFace timeouts.

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,7 +24,9 @@
 ## 节点列表
 
 ### 1. Qwen3-TTS 声音设计 (`VoiceDesignNode`)
+
 根据文本描述生成独有的声音。
+
 - **输入**:
   - `text`: 要合成的目标文本。
   - `instruct`: 声音描述指令（例如：“一个温和的高音女声”）。
@@ -32,7 +34,9 @@
 - **能力**: 最适合创建“想象中的”声音或特定的人设。
 
 ### 2. Qwen3-TTS 声音克隆 (`VoiceCloneNode`)
+
 从参考音频剪辑中克隆声音。
+
 - **输入**:
   - `ref_audio`: 一段短的（5-15秒）参考音频。
   - `ref_text`: 参考音频中的文本内容（有助于提高质量）。
@@ -40,28 +44,69 @@
   - `model_choice`: 可选择 **0.6B**（速度快）或 **1.7B**（质量高）。
 
 ### 3. Qwen3-TTS 预设声音 (`CustomVoiceNode`)
+
 使用预设说话人的标准 TTS。
+
 - **输入**:
   - `text`: 目标文本。
   - `speaker`: 从预设声音中选择（Aiden, Eric, Serena 等）。
   - `instruct`: 可选的风格指令。
 
 ### 4. Qwen3-TTS 声音克隆 Prompt (`VoiceClonePromptNode`) [新增]
+
 从参考音频中提取并复用声音特征。
+
 - **能力**: 只需提取一次“Prompt 节点”，即可在多个 `VoiceCloneNode` 实例中复用，提高生成效率并保证音质一致性。
 
 ### 5. Qwen3-TTS 多角色对话 (`DialogueInferenceNode`) [新增]
+
 支持多角色、多说话人的复杂对话合成。
+
 - **能力**: 在单个节点内处理多角色语音合成，非常适合有声书制作或角色扮演场景。
 
 ## 安装
 
 确保已安装以下依赖：
+
 ```bash
 pip install torch torchaudio transformers librosa accelerate
 ```
 
+## 模型下载 (离线使用)
+
+默认情况下，节点会尝试自动从 Hugging Face 下载模型。如果无法连接或需要离线使用，您可以手动下载模型。
+
+### 选项 1: 自动下载脚本 (推荐)
+
+您只需运行提供的 Python 脚本即可将所有必要的模型下载到正确的位置：
+
+```bash
+python download_models.py
+```
+
+_注意：该脚本会尝试自动检测您的 ComfyUI 安装位置。您还可以传递参数，如 `--small` 以下载 0.6B 模型。_
+
+### 选项 2: 手动下载
+
+1. 在您的 ComfyUI `models` 目录下创建一个名为 `qwen-tts` 的文件夹：
+
+   ```
+   ComfyUI/models/qwen-tts/
+   ```
+
+2. 从 Hugging Face 下载模型并放入相应的子文件夹中。文件夹名称**必须完全一致**：
+
+| 模型类型               | 文件夹名称 (在 `qwen-tts` 内部创建) | Hugging Face 仓库                                                   |
+| ---------------------- | ----------------------------------- | ------------------------------------------------------------------- |
+| **Tokenizer** (必须)   | `Qwen3-TTS-Tokenizer-12Hz`          | [链接](https://huggingface.co/Qwen/Qwen3-TTS-Tokenizer-12Hz)        |
+| **Voice Clone** (Base) | `Qwen3-TTS-12Hz-1.7B-Base`          | [链接](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base)        |
+| **Voice Design**       | `Qwen3-TTS-12Hz-1.7B-VoiceDesign`   | [链接](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign) |
+| **Custom Voice**       | `Qwen3-TTS-12Hz-1.7B-CustomVoice`   | [链接](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice) |
+
+> **提示**: 如需 0.6B 版本模型，请查看 [Qwen3 Collection](https://huggingface.co/collections/Qwen/qwen3-tts)。
+
 ## 最佳实践技巧
+
 - **克隆**: 使用清晰、无背景噪音的参考音频（5-15 秒）。
 - **显存**: 使用 `bf16` 精度可以在几乎不损失质量的情况下大幅节省内存。
 - **本地模型**: 预先将权重下载到 `models/qwen-tts/` 以优先进行本地加载，避免 HuggingFace 连接超时。

--- a/download_models.py
+++ b/download_models.py
@@ -1,0 +1,124 @@
+import os
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from huggingface_hub import snapshot_download
+except ImportError:
+    print("Error: 'huggingface_hub' is required. Please install it using: pip install huggingface_hub")
+    print("错误: 需要安装 'huggingface_hub'。请使用 pip install huggingface_hub 安装")
+    sys.exit(1)
+
+# Default models (1.7B is the recommended default)
+DEFAULT_MODELS = {
+    "tokenizer": "Qwen/Qwen3-TTS-Tokenizer-12Hz",
+    "base_1_7b": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+    "voice_design": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    "custom_voice": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+}
+
+SMALL_MODELS = {
+    "base_0_6b": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+    "custom_voice_0_6b": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+}
+
+def get_comfy_models_path():
+    """Attempt to find the ComfyUI/models directory relative to this script."""
+    # Assuming script is in ComfyUI/custom_nodes/ComfyUI-Qwen-TTS/
+    current_path = Path(__file__).parent.resolve()
+    
+    # Check standard ComfyUI structure: ../../models
+    potential_models = current_path.parent.parent / "models"
+    if potential_models.exists() and potential_models.is_dir():
+        return potential_models
+    
+    return None
+
+def download_model(repo_id, target_root):
+    folder_name = repo_id.split("/")[-1]
+    target_path = target_root / folder_name
+    
+    print(f"\n🔹 Processing (处理中): {repo_id}")
+    print(f"   Target (目标路径): {target_path}")
+    
+    if target_path.exists():
+        print(f"   ✅ Target directory exists. Checking for updates... (目标目录已存在，检查更新...)")
+    else:
+        print(f"   📥 Downloading new model... (正在下载新模型...)")
+        
+    try:
+        snapshot_download(repo_id=repo_id, local_dir=target_path)
+        print(f"   ✅ Success (成功): {repo_id}")
+    except Exception as e:
+        print(f"   ❌ Failed to download (下载失败) {repo_id}: {e}")
+        return False
+    return True
+
+def main():
+    parser = argparse.ArgumentParser(description="Download Qwen-TTS models for ComfyUI.")
+    parser.add_argument("--target", type=str, help="Specific target directory for models. Defaults to ComfyUI/models/qwen-tts if found, else ./models/qwen-tts")
+    parser.add_argument("--small", action="store_true", help="Download 0.6B models instead of 1.7B (where available)")
+    parser.add_argument("--all", action="store_true", help="Download ALL models (0.6B and 1.7B)")
+    args = parser.parse_args()
+
+    # Determine target directory
+    if args.target:
+        base_dir = Path(args.target)
+    else:
+        comfy_models = get_comfy_models_path()
+        if comfy_models:
+            print(f"📍 Detected ComfyUI models directory at (检测到 ComfyUI 模型目录): {comfy_models}")
+            base_dir = comfy_models / "qwen-tts"
+        else:
+            print("⚠️  Could not detect ComfyUI models directory. using local './models/qwen-tts' (未检测到 ComfyUI 模型目录，使用本地路径)")
+            base_dir = Path(os.getcwd()) / "models" / "qwen-tts"
+
+    # Create directory
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"❌ Error creating directory (创建目录失败) {base_dir}: {e}")
+        sys.exit(1)
+
+    print(f"📂 Models will be downloaded to (模型将下载至): {base_dir}")
+
+    # Build download list
+    models_to_download = [DEFAULT_MODELS["tokenizer"]]
+    
+    if args.all:
+        models_to_download.extend(DEFAULT_MODELS.values())
+        models_to_download.extend(SMALL_MODELS.values())
+        # Remove duplicates if any (tokenizer)
+        models_to_download = list(set(models_to_download))
+    elif args.small:
+        # User requested small models
+        models_to_download.append(SMALL_MODELS["base_0_6b"])
+        models_to_download.append(SMALL_MODELS["custom_voice_0_6b"])
+        # VoiceDesign only exists in 1.7B, so we exclude it or warn? 
+        # Usually users want functional nodes, so maybe we skip VoiceDesign for 'small' or include 1.7B?
+        # Let's include VoiceDesign 1.7B anyway because there is no 0.6B alternative and it's a key feature.
+        print("ℹ️  Note: VoiceDesign model is only available in 1.7B. Downloading it to ensure full functionality.")
+        print("ℹ️  注意: VoiceDesign 模型仅有 1.7B 版本。正在下载以确保功能完整。")
+        models_to_download.append(DEFAULT_MODELS["voice_design"])
+    else:
+        # Default (1.7B)
+        models_to_download.extend([
+             DEFAULT_MODELS["base_1_7b"],
+             DEFAULT_MODELS["voice_design"],
+             DEFAULT_MODELS["custom_voice"]
+        ])
+
+    print("🚀 Starting download... (开始下载...)")
+    
+    # Execute
+    for model in models_to_download:
+        # Handle duplicates from the dictionary values logic
+        if model == DEFAULT_MODELS["tokenizer"] and models_to_download.count(model) > 1:
+            continue
+        download_model(model, base_dir)
+
+    print("\n🎉 All downloads finished. (所有下载已完成)")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ einops
 tiktoken
 sentencepiece
 sox
+huggingface_hub


### PR DESCRIPTION
## Summary [概述]

This PR adds a convenience script for downloading Qwen-TTS models and documents the offline installation process.

本 PR 添加了一个便捷的模型下载脚本，并记录了离线安装流程。

## Changes [更改内容]

- **New `download_models.py` script** [新增 `download_models.py` 脚本]
  - Auto-detects ComfyUI models directory [自动检测 ComfyUI 模型目录]
  - Supports `--small` flag for 0.6B models [支持 `--small` 参数下载 0.6B 模型]
  - Supports `--all` flag to download all model variants [支持 `--all` 参数下载所有模型]
  - Bilingual CLI output (English/Chinese) [双语命令行输出]

- **Updated README.md and README_CN.md** [更新 README.md 和 README_CN.md]
  - Added "Model Downloading" section with automatic and manual options [添加"模型下载"章节，包含自动和手动两种方式]
  - Minor markdown formatting improvements [优化 Markdown 格式]

- **Updated requirements.txt** [更新 requirements.txt]
  - Added `huggingface_hub` dependency [添加 `huggingface_hub` 依赖]

## Usage [使用方法]

```bash
# Download default 1.7B models [下载默认 1.7B 模型]
python download_models.py

# Download 0.6B models [下载 0.6B 模型]
python download_models.py --small

# Download all models [下载所有模型]
python download_models.py --all
```
