### PR TITLE
Custom pause settings in generate_dialogue function

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -937,10 +937,15 @@ class DialogueInferenceNode:
                 "precision": (["bf16", "fp32"], {"default": "bf16"}),
                 "language": (DEMO_LANGUAGES, {"default": "Auto"}),
                 # RENAMED: pause_seconds -> pause_linebreak
+                # Linebreak Pause
                 "pause_linebreak": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 5.0, "step": 0.1, "tooltip": "Silence duration between lines"}),
                 # NEW: Period and Comma pause settings
                 "period_pause": ("FLOAT", {"default": 0.4, "min": 0.0, "max": 5.0, "step": 0.1, "tooltip": "Silence duration after periods (.)"}),
                 "comma_pause": ("FLOAT", {"default": 0.2, "min": 0.0, "max": 5.0, "step": 0.1, "tooltip": "Silence duration after commas (,)"}),
+                # ### NEW INPUTS ###
+                "question_pause": ("FLOAT", {"default": 0.6, "min": 0.0, "max": 5.0, "step": 0.1, "tooltip": "Silence duration after question marks (?)"}),
+                "hyphen_pause": ("FLOAT", {"default": 0.3, "min": 0.0, "max": 5.0, "step": 0.1, "tooltip": "Silence duration after hyphens (-)"}),
+                
                 "merge_outputs": ("BOOLEAN", {"default": True, "tooltip": "Merge all dialogue segments into a single long audio"}),
                 "batch_size": ("INT", {"default": 4, "min": 1, "max": 32, "step": 1, "tooltip": "Number of lines to process in parallel. Larger = faster but more VRAM."}),
             },
@@ -961,8 +966,8 @@ class DialogueInferenceNode:
     FUNCTION = "generate_dialogue"
     CATEGORY = "Qwen3-TTS"
     DESCRIPTION = "DialogueInference: Execute a script with multiple roles and generate continuous speech."
-
-    def generate_dialogue(self, script: str, role_bank: Dict[str, Any], model_choice: str, device: str, precision: str, language: str, pause_linebreak: float, period_pause: float, comma_pause: float, merge_outputs: bool, batch_size: int, seed: int = 0, max_new_tokens_per_line: int = 2048, top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
+    # ### UPDATED ARGUMENTS: Added question_pause, hyphen_pause
+    def generate_dialogue(self, script: str, role_bank: Dict[str, Any], model_choice: str, device: str, precision: str, language: str, pause_linebreak: float, period_pause: float, comma_pause: float, question_pause: float, hyphen_pause: float, merge_outputs: bool, batch_size: int, seed: int = 0, max_new_tokens_per_line: int = 2048, top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
         if not script or not role_bank:
             raise RuntimeError("Script and Role Bank are required")
 
@@ -987,14 +992,14 @@ class DialogueInferenceNode:
         lines = script.strip().split("\n")
         
         texts_to_gen = []
-        prompts_to_gen = [] 
+        prompts_to_gen = [] # This must be a flat list of VoiceClonePromptItem
         langs_to_gen = []
         pauses_to_gen = [] 
         
         mapped_lang = LANGUAGE_MAP.get(language, "auto")
         
-        # Internal tag for processing splits (hidden from user)
-        pause_pattern = r'\[pause=([\d\.]+)\]'
+        # Internal tag for processing splits (Renamed to [break=] to separate from user manual input)
+        pause_pattern = r'\[break=([\d\.]+)\]'
 
         print(f"🎬 [Qwen3-TTS] Preparing batched inference for {len(lines)} lines...")
 
@@ -1021,19 +1026,29 @@ class DialogueInferenceNode:
             if role_name not in role_bank:
                 print(f"⚠️ [Qwen3-TTS] Role '{role_name}' not found in Role Bank, skipping line: {line[:20]}...")
                 continue
-
             # role_bank[role_name] is a List[VoiceClonePromptItem] (from create_voice_clone_prompt)
             role_prompts = role_bank[role_name]
             current_prompt = role_prompts[0] if isinstance(role_prompts, list) else role_prompts
 
             # --- AUTO-PUNCTUATION LOGIC ---
-            # Replace punctuation with temporary internal tags so we can split correctly.
-            # We use regex lookahead (?!\d) to NOT replace dots inside numbers (e.g. 1.5)
-            if period_pause > 0:
-                text = re.sub(r'\.(?!\d)', f'. [pause={period_pause}]', text)
+            # Replaced [pause=] with [break=] to use internal system only.
+            # Using regex lookahead (?!\d) to avoid replacing punctuation inside numbers (e.g. 1.5, -5)
             
+            # 1. Period
+            if period_pause > 0:
+                text = re.sub(r'\.(?!\d)', f'. [break={period_pause}]', text)
+            
+            # 2. Comma
             if comma_pause > 0:
-                text = re.sub(r',(?!\d)', f', [pause={comma_pause}]', text)
+                text = re.sub(r',(?!\d)', f', [break={comma_pause}]', text)
+                
+            # 3. Question Mark (Escaped as \?)
+            if question_pause > 0:
+                text = re.sub(r'\?(?!\d)', f'? [break={question_pause}]', text)
+
+            # 4. Hyphen (Escaped as \-, or literal -)
+            if hyphen_pause > 0:
+                text = re.sub(r'-(?!\d)', f'- [break={hyphen_pause}]', text)
 
             # --- SPLIT & PARSE LOGIC ---
             parts = re.split(pause_pattern, text)
@@ -1065,7 +1080,7 @@ class DialogueInferenceNode:
             results = []
             num_lines = len(texts_to_gen)
             sr = 24000
-            
+
             # Micro-matching: process in chunks to save VRAM
             for i in range(0, num_lines, batch_size):
                 chunk_texts = texts_to_gen[i:i + batch_size]
@@ -1104,7 +1119,6 @@ class DialogueInferenceNode:
                         silence_len = int(this_pause * sr)
                         silence = torch.zeros((1, 1, silence_len))
                         results.append(silence)
-                
                 # Cleanup cache after each chunk
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
@@ -1138,7 +1152,6 @@ class DialogueInferenceNode:
             
             batched_waveform = torch.cat(padded_results, dim=0)
             audio_data = {"waveform": batched_waveform, "sample_rate": sr}
-            
             # Unload model if requested
             if unload_model_after_generate and hasattr(model, '_unload_callback') and model._unload_callback:
                 model._unload_callback()


### PR DESCRIPTION
Renamed 'pause_seconds' to 'pause_linebreak' and added new settings for period and comma recognition and custom pause length. Works better for voice clones.

Realized this was addressed differently today but here is a fine-tuned controllable approach that works.