### PR TITLE
Fix leading [break=N] pauses in dialogue inference

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -13,6 +13,8 @@ import types
 from comfy import model_management
 from comfy.utils import ProgressBar
 
+from .pause_utils import extract_leading_pause
+
 # Register "qwen-tts" model folder for extra_model_paths.yaml support
 try:
     folder_paths.add_model_folder_path("qwen-tts", os.path.join(folder_paths.models_dir, "qwen-tts"))
@@ -1165,6 +1167,7 @@ class DialogueInferenceNode:
         texts_to_gen = []
         prompts_to_gen = []
         langs_to_gen = []
+        leading_pauses_to_gen = []
         pauses_to_gen = []
 
         mapped_lang = LANGUAGE_MAP.get(language, "auto")
@@ -1192,6 +1195,8 @@ class DialogueInferenceNode:
 
             if role_name not in role_bank:
                 continue
+
+            text, leading_pause = extract_leading_pause(text)
             # role_bank[role_name] can be a prompt list OR the new packaged dict (if loaded via RoleBank from LoadSpeaker)
             role_data = role_bank[role_name]
             
@@ -1209,6 +1214,8 @@ class DialogueInferenceNode:
             
             segments = split_text_by_pauses(text, config)
 
+            first_generated_segment = True
+
             for segment_text, current_segment_pause in segments:
                 pronounceable = re.sub(r'[^\w\u4e00-\u9fa5]', '', segment_text)
                 if not pronounceable.strip():
@@ -1223,7 +1230,9 @@ class DialogueInferenceNode:
                 texts_to_gen.append(clean_seg_text)
                 prompts_to_gen.append(current_prompt)
                 langs_to_gen.append(mapped_lang)
+                leading_pauses_to_gen.append(leading_pause if first_generated_segment else 0.0)
                 pauses_to_gen.append(current_segment_pause)
+                first_generated_segment = False
 
             if pauses_to_gen:
                 pauses_to_gen[-1] += pause_linebreak
@@ -1246,6 +1255,7 @@ class DialogueInferenceNode:
                 chunk_texts = texts_to_gen[i:i + batch_size]
                 chunk_prompts = prompts_to_gen[i:i + batch_size]
                 chunk_langs = langs_to_gen[i:i + batch_size]
+                chunk_leading_pauses = leading_pauses_to_gen[i:i + batch_size]
                 chunk_pauses = pauses_to_gen[i:i + batch_size]
 
                 current_chunk = i // batch_size + 1
@@ -1271,12 +1281,17 @@ class DialogueInferenceNode:
                         if waveform.shape[1] > 1:
                             waveform = torch.mean(waveform, dim=1, keepdim=True)
 
+                    leading_pause = chunk_leading_pauses[j]
+                    if leading_pause > 0:
+                        silence_len = int(leading_pause * sr)
+                        results.append(waveform.new_zeros((1, 1, silence_len)))
+
                     results.append(waveform)
 
                     this_pause = chunk_pauses[j]
                     if this_pause > 0:
                         silence_len = int(this_pause * sr)
-                        silence = torch.zeros((1, 1, silence_len))
+                        silence = waveform.new_zeros((1, 1, silence_len))
                         results.append(silence)
 
                 if hasattr(torch, 'xpu') and torch.xpu.is_available():

--- a/pause_utils.py
+++ b/pause_utils.py
@@ -1,0 +1,19 @@
+import re
+from typing import Tuple
+
+
+_LEADING_BREAK_PATTERN = re.compile(
+    r"^\s*\[break=([0-9]+(?:\.[0-9]+)?)\]\s*",
+    re.IGNORECASE,
+)
+
+
+def extract_leading_pause(text: str) -> Tuple[str, float]:
+    """Remove leading break tags and return their combined duration."""
+    pause_seconds = 0.0
+
+    while match := _LEADING_BREAK_PATTERN.match(text):
+        pause_seconds += float(match.group(1))
+        text = text[match.end():]
+
+    return text, pause_seconds

--- a/tests/test_pause_utils.py
+++ b/tests/test_pause_utils.py
@@ -1,0 +1,40 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pause_utils import extract_leading_pause
+
+
+class ExtractLeadingPauseTests(unittest.TestCase):
+    def test_extracts_leading_pause(self):
+        text, pause = extract_leading_pause("[break=5]Hello")
+
+        self.assertEqual(text, "Hello")
+        self.assertEqual(pause, 5.0)
+
+    def test_combines_consecutive_leading_pauses(self):
+        text, pause = extract_leading_pause(" [break=1.5] [break=2] Hello")
+
+        self.assertEqual(text, "Hello")
+        self.assertEqual(pause, 3.5)
+
+    def test_accepts_case_insensitive_tag(self):
+        text, pause = extract_leading_pause("[BREAK=0.5] Hello")
+
+        self.assertEqual(text, "Hello")
+        self.assertEqual(pause, 0.5)
+
+    def test_does_not_extract_inline_pause(self):
+        original = "Hello [break=5] world"
+
+        text, pause = extract_leading_pause(original)
+
+        self.assertEqual(text, original)
+        self.assertEqual(pause, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve leading `[break=N]` tags on dialogue lines
- prepend deterministic silence before the corresponding generated waveform
- support consecutive and case-insensitive leading break tags
- add regression tests for leading and inline pause parsing

## Testing

- `python -m unittest discover -s tests -v`
