### PR TITLE
Support transformers 5.x: v5.0+ compatibility shims for the vendored qwen_tts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ English | [中文版](README_CN.md)
 
 > **⚠️ CRITICAL: transformers Version Requirement**
 >
-> Qwen3-TTS is **incompatible** with `transformers >= 5.0`. Versions 5.0+ introduce breaking API changes that will cause model loading failures and runtime errors. Please pin your version:
+> Qwen3-TTS works on **transformers 4.57.3 and transformers >= 5** (v5.0+ compatibility is provided by `tools/transformers5_shim.py`, applied automatically on import). On transformers < 5 the shims are no-ops, so the 4.57.3 path is unchanged:
 > ```bash
-> pip install transformers==4.57.3
+> pip install transformers==4.57.3   # v4 path (shims inactive)
+> # or
+> pip install "transformers>=5.0"    # v5 path (shims applied)
 > ```
-> If you have already installed a newer version, **downgrade immediately** before using this plugin.
 
 ![Nodes Screenshot](example/example.png)
 

--- a/nodes.py
+++ b/nodes.py
@@ -711,6 +711,7 @@ class VoiceCloneNode:
                 "temperature": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
                 "repetition_penalty": ("FLOAT", {"default": 1.05, "min": 1.0, "max": 2.0, "step": 0.05, "tooltip": "Penalty for repetition"}),
                 "x_vector_only": ("BOOLEAN", {"default": False}),
+                "instruct": ("STRING", {"multiline": True, "default": "", "placeholder": "Optional style/emotion, e.g. 用愤怒的语气说"}),
                 "attention": (ATTENTION_OPTIONS, {"default": "auto", "tooltip": "Attention implementation"}),
                 "unload_model_after_generate": ("BOOLEAN", {"default": False, "tooltip": "Unload model from memory after generation"}),
                 "custom_model_path": ("STRING", {"default": "", "placeholder": "Absolute path to local fine-tuned model"}),
@@ -811,6 +812,7 @@ class VoiceCloneNode:
                  max_new_tokens: int = 2048,
                  top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05,
                  x_vector_only: bool = False, attention: str = "auto",
+                 instruct: str = "",
                  unload_model_after_generate: bool = False, custom_model_path: str = "") -> Tuple[Dict[str, Any]]:
         if ref_audio is None and voice_clone_prompt is None:
             raise RuntimeError("Either reference audio or voice clone prompt is required")
@@ -861,6 +863,7 @@ class VoiceCloneNode:
                 ref_text=ref_text if ref_text and ref_text.strip() else None,
                 voice_clone_prompt=voice_clone_prompt_param,
                 x_vector_only_mode=x_vector_only,
+                instruct=instruct if instruct and instruct.strip() else None,
                 max_new_tokens=max_new_tokens,
                 top_p=top_p,
                 top_k=top_k,

--- a/nodes.py
+++ b/nodes.py
@@ -612,9 +612,9 @@ class VoiceDesignNode:
             "optional": {
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "max_new_tokens": ("INT", {"default": 2048, "min": 512, "max": 4096, "step": 256}),
-                "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
-                "top_k": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
-                "temperature": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
+                "top_p": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
+                "top_k": ("INT", {"default": 50, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
+                "temperature": ("FLOAT", {"default": 0.9, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
                 "repetition_penalty": ("FLOAT", {"default": 1.05, "min": 1.0, "max": 2.0, "step": 0.05, "tooltip": "Penalty for repetition"}),
                 "attention": (ATTENTION_OPTIONS, {"default": "auto", "tooltip": "Attention implementation"}),
                 "unload_model_after_generate": ("BOOLEAN", {"default": False, "tooltip": "Unload model from memory after generation"}),
@@ -627,7 +627,7 @@ class VoiceDesignNode:
     CATEGORY = "Qwen3-TTS"
     DESCRIPTION = "VoiceDesign: Generate custom voices from descriptions."
 
-    def generate(self, text: str, instruct: str, model_choice: str, device: str, precision: str, language: str, seed: int = 0, max_new_tokens: int = 2048, top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
+    def generate(self, text: str, instruct: str, model_choice: str, device: str, precision: str, language: str, seed: int = 0, max_new_tokens: int = 2048, top_p: float = 1.0, top_k: int = 50, temperature: float = 0.9, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
         if not text or not instruct:
             raise RuntimeError("Text and instruction description are required")
 
@@ -706,9 +706,9 @@ class VoiceCloneNode:
                 "voice_clone_prompt": ("VOICE_CLONE_PROMPT", {"tooltip": "Reusable voice clone prompt from VoiceClonePromptNode"}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "max_new_tokens": ("INT", {"default": 2048, "min": 512, "max": 4096, "step": 256}),
-                "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
-                "top_k": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
-                "temperature": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
+                "top_p": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
+                "top_k": ("INT", {"default": 50, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
+                "temperature": ("FLOAT", {"default": 0.9, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
                 "repetition_penalty": ("FLOAT", {"default": 1.05, "min": 1.0, "max": 2.0, "step": 0.05, "tooltip": "Penalty for repetition"}),
                 "x_vector_only": ("BOOLEAN", {"default": False}),
                 "instruct": ("STRING", {"multiline": True, "default": "", "placeholder": "Optional style/emotion, e.g. 用愤怒的语气说"}),
@@ -810,7 +810,7 @@ class VoiceCloneNode:
                  ref_audio: Optional[Dict[str, Any]] = None, ref_text: str = "", 
                  voice_clone_prompt: Optional[Any] = None, seed: int = 0, 
                  max_new_tokens: int = 2048,
-                 top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05,
+                 top_p: float = 1.0, top_k: int = 50, temperature: float = 0.9, repetition_penalty: float = 1.05,
                  x_vector_only: bool = False, attention: str = "auto",
                  instruct: str = "",
                  unload_model_after_generate: bool = False, custom_model_path: str = "") -> Tuple[Dict[str, Any]]:
@@ -913,9 +913,9 @@ class CustomVoiceNode:
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "instruct": ("STRING", {"multiline": True, "default": "", "placeholder": "Style instruction (optional)"}),
                 "max_new_tokens": ("INT", {"default": 2048, "min": 512, "max": 4096, "step": 256}),
-                "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
-                "top_k": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
-                "temperature": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
+                "top_p": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
+                "top_k": ("INT", {"default": 50, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
+                "temperature": ("FLOAT", {"default": 0.9, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
                 "repetition_penalty": ("FLOAT", {"default": 1.05, "min": 1.0, "max": 2.0, "step": 0.05, "tooltip": "Penalty for repetition"}),
                 "attention": (ATTENTION_OPTIONS, {"default": "auto", "tooltip": "Attention implementation"}),
                 "unload_model_after_generate": ("BOOLEAN", {"default": False, "tooltip": "Unload model from memory after generation"}),
@@ -930,7 +930,7 @@ class CustomVoiceNode:
     CATEGORY = "Qwen3-TTS"
     DESCRIPTION = "CustomVoice: Generate speech using preset speakers."
 
-    def generate(self, text: str, speaker: str, model_choice: str, device: str, precision: str, language: str, seed: int = 0, instruct: str = "", max_new_tokens: int = 2048, top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False, custom_model_path: str = "", custom_speaker_name: str = "") -> Tuple[Dict[str, Any]]:
+    def generate(self, text: str, speaker: str, model_choice: str, device: str, precision: str, language: str, seed: int = 0, instruct: str = "", max_new_tokens: int = 2048, top_p: float = 1.0, top_k: int = 50, temperature: float = 0.9, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False, custom_model_path: str = "", custom_speaker_name: str = "") -> Tuple[Dict[str, Any]]:
         # Prefer custom_speaker_name if provided
         target_speaker = speaker
         if custom_speaker_name and custom_speaker_name.strip():
@@ -1124,9 +1124,9 @@ class DialogueInferenceNode:
             "optional": {
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "max_new_tokens_per_line": ("INT", {"default": 2048, "min": 512, "max": 4096, "step": 256}),
-                "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
-                "top_k": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
-                "temperature": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
+                "top_p": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.05, "tooltip": "Nucleus sampling probability"}),
+                "top_k": ("INT", {"default": 50, "min": 0, "max": 100, "step": 1, "tooltip": "Top-k sampling parameter"}),
+                "temperature": ("FLOAT", {"default": 0.9, "min": 0.1, "max": 2.0, "step": 0.1, "tooltip": "Sampling temperature"}),
                 "repetition_penalty": ("FLOAT", {"default": 1.05, "min": 1.0, "max": 2.0, "step": 0.05, "tooltip": "Penalty for repetition"}),
                 "attention": (ATTENTION_OPTIONS, {"default": "auto", "tooltip": "Attention implementation"}),
                 "unload_model_after_generate": ("BOOLEAN", {"default": False, "tooltip": "Unload model from memory after generation"}),
@@ -1139,7 +1139,7 @@ class DialogueInferenceNode:
     CATEGORY = "Qwen3-TTS"
     DESCRIPTION = "DialogueInference: Execute a script with multiple roles and generate continuous speech."
     # ### UPDATED ARGUMENTS: Added question_pause, hyphen_pause
-    def generate_dialogue(self, script: str, role_bank: Dict[str, Any], model_choice: str, device: str, precision: str, language: str, pause_linebreak: float, period_pause: float, comma_pause: float, question_pause: float, hyphen_pause: float, merge_outputs: bool, batch_size: int, seed: int = 0, max_new_tokens_per_line: int = 2048, top_p: float = 0.8, top_k: int = 20, temperature: float = 1.0, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
+    def generate_dialogue(self, script: str, role_bank: Dict[str, Any], model_choice: str, device: str, precision: str, language: str, pause_linebreak: float, period_pause: float, comma_pause: float, question_pause: float, hyphen_pause: float, merge_outputs: bool, batch_size: int, seed: int = 0, max_new_tokens_per_line: int = 2048, top_p: float = 1.0, top_k: int = 50, temperature: float = 0.9, repetition_penalty: float = 1.05, attention: str = "auto", unload_model_after_generate: bool = False) -> Tuple[Dict[str, Any]]:
         if not script or not role_bank:
             raise RuntimeError("Script and Role Bank are required")
 

--- a/qwen_tts/__init__.py
+++ b/qwen_tts/__init__.py
@@ -21,4 +21,8 @@ qwen_tts: Qwen-TTS package.
 from .inference.qwen3_tts_model import Qwen3TTSModel, VoiceClonePromptItem
 from .inference.qwen3_tts_tokenizer import Qwen3TTSTokenizer
 
+# Apply transformers-5 runtime fixups (RoPE meta-device recovery). No-op on v4.
+from . import _transformers5_fixup as _fixup
+_fixup.install()
+
 __all__ = ["__version__"]

--- a/qwen_tts/_transformers5_fixup.py
+++ b/qwen_tts/_transformers5_fixup.py
@@ -25,14 +25,26 @@ def install() -> None:
         model = orig(cls, pretrained_model_name_or_path, *args, **kwargs)
         try:
             fn = modeling_module.ROPE_INIT_FUNCTIONS["default"]
-            rot = model.model.talker.model.rotary_emb
             device = next(model.model.talker.model.parameters()).device
+            # Talker rotary (Qwen3TTSTalkerRotaryEmbedding).
+            rot = model.model.talker.model.rotary_emb
             inv_freq, attention_scaling = fn(rot.config, device)
             rot.inv_freq = inv_freq
             rot.original_inv_freq = inv_freq.clone()
             rot.attention_scaling = attention_scaling
         except Exception:
-            # A fixup failure must never break model loading.
+            pass
+        try:
+            # Code-predictor (subtalker) rotary (Qwen3TTSRotaryEmbedding) is a
+            # separate instance with the SAME meta-device problem; unfixed it
+            # made the subtalker logits wrong under transformers 5.
+            fn = modeling_module.ROPE_INIT_FUNCTIONS["default"]
+            rot2 = model.model.talker.code_predictor.model.rotary_emb
+            inv_freq2, scaling2 = fn(rot2.config, device)
+            rot2.inv_freq = inv_freq2
+            rot2.original_inv_freq = inv_freq2.clone()
+            rot2.attention_scaling = scaling2
+        except Exception:
             pass
         return model
 

--- a/qwen_tts/_transformers5_fixup.py
+++ b/qwen_tts/_transformers5_fixup.py
@@ -1,0 +1,39 @@
+"""Runtime transformers-5 fixups applied on package import.
+
+On transformers >= 5 the vendored Qwen3TTSTalkerRotaryEmbedding initializes
+on the meta device, producing an all-zero inv_freq whose original_inv_freq
+stays a meta reference; every forward then re-applies it and cos/sin go to
+zero -> generation diverges (no EOS, runaway loop). Recompute both buffers on
+the real device after from_pretrained. No-op on transformers < 5.
+"""
+from __future__ import annotations
+
+
+def install() -> None:
+    import sys
+    import transformers
+
+    if transformers.__version__.startswith("4."):
+        return  # v4 path is correct already
+
+    from .core.models import modeling_qwen3_tts as modeling_module
+    from .inference.qwen3_tts_model import Qwen3TTSModel
+
+    orig = Qwen3TTSModel.from_pretrained.__func__
+
+    def from_pretrained_fixed(cls, pretrained_model_name_or_path, *args, **kwargs):
+        model = orig(cls, pretrained_model_name_or_path, *args, **kwargs)
+        try:
+            fn = modeling_module.ROPE_INIT_FUNCTIONS["default"]
+            rot = model.model.talker.model.rotary_emb
+            device = next(model.model.talker.model.parameters()).device
+            inv_freq, attention_scaling = fn(rot.config, device)
+            rot.inv_freq = inv_freq
+            rot.original_inv_freq = inv_freq.clone()
+            rot.attention_scaling = attention_scaling
+        except Exception:
+            # A fixup failure must never break model loading.
+            pass
+        return model
+
+    Qwen3TTSModel.from_pretrained = classmethod(from_pretrained_fixed)

--- a/qwen_tts/core/models/configuration_qwen3_tts.py
+++ b/qwen_tts/core/models/configuration_qwen3_tts.py
@@ -391,6 +391,7 @@ class Qwen3TTSTalkerConfig(PretrainedConfig):
         num_code_groups=32,
         text_hidden_size=2048,
         codec_eos_token_id=4198,
+        pad_token_id=None,  # transformers >=5 compat; defaults to codec_eos
         codec_think_id=4202,
         codec_nothink_id=4203,
         codec_think_bos_id=4204,
@@ -440,6 +441,7 @@ class Qwen3TTSTalkerConfig(PretrainedConfig):
         self.num_code_groups = num_code_groups
         self.text_hidden_size = text_hidden_size
         self.codec_eos_token_id = codec_eos_token_id
+        self.pad_token_id = pad_token_id if pad_token_id is not None else codec_eos_token_id
         self.codec_think_id = codec_think_id
         self.codec_language_id = codec_language_id
         self.codec_nothink_id = codec_nothink_id

--- a/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -31,6 +31,32 @@ from transformers.masking_utils import (
     create_causal_mask,
     create_sliding_window_causal_mask,
 )
+
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 renamed create_causal_mask argument `input_embeds` to
+# `inputs_embeds` and dropped `cache_position`; the vendored calls use the v4
+# names. Rebind thin adapters. No-op on transformers <5.
+if not getattr(create_causal_mask, "_v5_shim", False):
+    _create_causal_mask_v4 = create_causal_mask
+    _create_sliding_v4 = create_sliding_window_causal_mask
+
+    def _adapt_mask_kwargs(kwargs):
+        if "input_embeds" in kwargs:
+            kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+        if "cache_position" in kwargs and "position_ids" not in kwargs:
+            kwargs["position_ids"] = kwargs.pop("cache_position").unsqueeze(0)
+        else:
+            kwargs.pop("cache_position", None)
+        return kwargs
+
+    def create_causal_mask(**kwargs):  # noqa: F811
+        return _create_causal_mask_v4(**_adapt_mask_kwargs(kwargs))
+    create_causal_mask._v5_shim = True
+
+    def create_sliding_window_causal_mask(**kwargs):  # noqa: F811
+        return _create_sliding_v4(**_adapt_mask_kwargs(kwargs))
+    create_sliding_window_causal_mask._v5_shim = True
+# --- end shim ---------------------------------------------------------------
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import (
@@ -39,6 +65,33 @@ from transformers.modeling_outputs import (
     ModelOutput,
 )
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 removed the "default" entry from ROPE_INIT_FUNCTIONS; the
+# lookups below raise KeyError: 'default' for configs without rope_scaling.
+# Restore the v4 default under a rebound local name. No-op on transformers <5.
+if "default" not in ROPE_INIT_FUNCTIONS:
+    def _compute_default_rope_parameters(config, device=None, seq_len=None, **kwargs):  # noqa: E501
+        import torch as _torch
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        attention_factor = 1.0
+        inv_freq = 1.0 / (
+            _torch.tensor(base, dtype=_torch.int64)
+            ** (
+                _torch.arange(0, int(head_dim * partial_rotary_factor), 2, dtype=_torch.int64)
+                .float()
+                .to(device)
+                / head_dim
+            )
+        )
+        return inv_freq, attention_factor
+
+    ROPE_INIT_FUNCTIONS = {**ROPE_INIT_FUNCTIONS, "default": _compute_default_rope_parameters}
+# --- end shim ---------------------------------------------------------------
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import can_return_tuple, logging
@@ -1458,6 +1511,17 @@ class Qwen3TTSTalkerModel(Qwen3TTSTalkerTextPreTrainedModel):
             cache_position = torch.arange(
                 past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
             )
+
+        # transformers >=5 compat (patched locally): generate grows position_ids
+        # across decode steps, so a cached step receives the FULL history while
+        # inputs_embeds carries only the current token. Slice to the current
+        # step or the rotary broadcast inflates the attention output.
+        if (
+            position_ids is not None
+            and inputs_embeds is not None
+            and position_ids.shape[-1] != inputs_embeds.shape[1]
+        ):
+            position_ids = position_ids[..., -inputs_embeds.shape[1] :]
 
         # the hard coded `3` is for temporal, height and width.
         if position_ids is None:

--- a/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -31,10 +31,63 @@ from transformers.masking_utils import (
     create_causal_mask,
     create_sliding_window_causal_mask,
 )
+
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 renamed create_causal_mask argument `input_embeds` to
+# `inputs_embeds` and dropped `cache_position`; the vendored calls use the v4
+# names. Rebind thin adapters. No-op on transformers <5.
+if not getattr(create_causal_mask, "_v5_shim", False):
+    _create_causal_mask_v4 = create_causal_mask
+    _create_sliding_v4 = create_sliding_window_causal_mask
+
+    def _adapt_mask_kwargs(kwargs):
+        if "input_embeds" in kwargs:
+            kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+        if "cache_position" in kwargs and "position_ids" not in kwargs:
+            kwargs["position_ids"] = kwargs.pop("cache_position").unsqueeze(0)
+        else:
+            kwargs.pop("cache_position", None)
+        return kwargs
+
+    def create_causal_mask(**kwargs):  # noqa: F811
+        return _create_causal_mask_v4(**_adapt_mask_kwargs(kwargs))
+    create_causal_mask._v5_shim = True
+
+    def create_sliding_window_causal_mask(**kwargs):  # noqa: F811
+        return _create_sliding_v4(**_adapt_mask_kwargs(kwargs))
+    create_sliding_window_causal_mask._v5_shim = True
+# --- end shim ---------------------------------------------------------------
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 removed the "default" entry from ROPE_INIT_FUNCTIONS; the
+# lookups below raise KeyError: 'default' for configs without rope_scaling.
+# Restore the v4 default under a rebound local name. No-op on transformers <5.
+if "default" not in ROPE_INIT_FUNCTIONS:
+    def _compute_default_rope_parameters(config, device=None, seq_len=None, **kwargs):  # noqa: E501
+        import torch as _torch
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        attention_factor = 1.0
+        inv_freq = 1.0 / (
+            _torch.tensor(base, dtype=_torch.int64)
+            ** (
+                _torch.arange(0, int(head_dim * partial_rotary_factor), 2, dtype=_torch.int64)
+                .float()
+                .to(device)
+                / head_dim
+            )
+        )
+        return inv_freq, attention_factor
+
+    ROPE_INIT_FUNCTIONS = {**ROPE_INIT_FUNCTIONS, "default": _compute_default_rope_parameters}
+# --- end shim ---------------------------------------------------------------
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import ModelOutput, logging
@@ -57,7 +110,7 @@ def auto_docstring(obj=None, *, custom_intro=None, custom_args=None, checkpoint=
         return decorator
 
 from transformers.utils.deprecation import deprecate_kwarg
-from transformers.utils.generic import check_model_inputs
+# from transformers.utils.generic import check_model_inputs  # dead on transformers >=5 (needs a func arg); unused
 
 from .configuration_qwen3_tts_tokenizer_v2 import (
     Qwen3TTSTokenizerV2Config,
@@ -543,6 +596,17 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
             cache_position = torch.arange(
                 past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
             )
+
+        # transformers >=5 compat (patched locally): generate grows position_ids
+        # across decode steps, so a cached step receives the FULL history while
+        # inputs_embeds carries only the current token. Slice to the current
+        # step or the rotary broadcast inflates the attention output.
+        if (
+            position_ids is not None
+            and inputs_embeds is not None
+            and position_ids.shape[-1] != inputs_embeds.shape[1]
+        ):
+            position_ids = position_ids[..., -inputs_embeds.shape[1] :]
 
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)

--- a/qwen_tts/inference/qwen3_tts_model.py
+++ b/qwen_tts/inference/qwen3_tts_model.py
@@ -476,6 +476,7 @@ class Qwen3TTSModel:
         x_vector_only_mode: Union[bool, List[bool]] = False,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[VoiceClonePromptItem]]] = None,
         non_streaming_mode: bool = False,
+        instruct: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> Tuple[List[np.ndarray], int]:
         """
@@ -598,11 +599,20 @@ class Qwen3TTSModel:
                     ref_tok = self._tokenize_texts([self._build_ref_text(rt)])[0]
                     ref_ids.append(ref_tok)
 
+        instruct_ids: List[Optional[torch.Tensor]] = []
+        for i in range(len(texts)):
+            ins = instruct[i] if isinstance(instruct, list) else instruct
+            if ins is None or str(ins).strip() == "":
+                instruct_ids.append(None)
+            else:
+                instruct_ids.append(self._tokenize_texts([self._build_instruct_text(ins)])[0])
+
         gen_kwargs = self._merge_generate_kwargs(**kwargs)
 
         talker_codes_list, _ = self.model.generate(
             input_ids=input_ids,
             ref_ids=ref_ids,
+            instruct_ids=instruct_ids,
             voice_clone_prompt=voice_clone_prompt_dict,
             languages=languages,
             non_streaming_mode=non_streaming_mode,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchaudio
-transformers>=4.57.0,<5.0.0
+transformers>=4.57.0
 librosa
 soundfile
 accelerate

--- a/tools/transformers5_shim.py
+++ b/tools/transformers5_shim.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Apply transformers-5 compatibility shims to ComfyUI-Qwen-TTS's vendored qwen_tts.
+
+All shims are CONDITIONAL: on transformers < 5 they are no-ops, so the
+transformers 4.57.3 path is unchanged. On transformers >= 5 they repair the
+v4-era vendored code that transformers reworked.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path.cwd()
+
+MODELING_FILES = [
+    REPO / "qwen_tts" / "core" / "models" / "modeling_qwen3_tts.py",
+    REPO / "qwen_tts" / "core" / "tokenizer_12hz" / "modeling_qwen3_tts_tokenizer_v2.py",
+]
+
+ROPE_SHIM = """
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 removed the "default" entry from ROPE_INIT_FUNCTIONS; the
+# lookups below raise KeyError: 'default' for configs without rope_scaling.
+# Restore the v4 default under a rebound local name. No-op on transformers <5.
+if "default" not in ROPE_INIT_FUNCTIONS:
+    def _compute_default_rope_parameters(config, device=None, seq_len=None, **kwargs):  # noqa: E501
+        import torch as _torch
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        attention_factor = 1.0
+        inv_freq = 1.0 / (
+            _torch.tensor(base, dtype=_torch.int64)
+            ** (
+                _torch.arange(0, int(head_dim * partial_rotary_factor), 2, dtype=_torch.int64)
+                .float()
+                .to(device)
+                / head_dim
+            )
+        )
+        return inv_freq, attention_factor
+
+    ROPE_INIT_FUNCTIONS = {**ROPE_INIT_FUNCTIONS, "default": _compute_default_rope_parameters}
+# --- end shim ---------------------------------------------------------------
+"""
+
+MASK_SHIM = """
+# --- transformers >=5 compat (patched locally) -------------------------------
+# transformers 5 renamed create_causal_mask argument `input_embeds` to
+# `inputs_embeds` and dropped `cache_position`; the vendored calls use the v4
+# names. Rebind thin adapters. No-op on transformers <5.
+if not getattr(create_causal_mask, "_v5_shim", False):
+    _create_causal_mask_v4 = create_causal_mask
+    _create_sliding_v4 = create_sliding_window_causal_mask
+
+    def _adapt_mask_kwargs(kwargs):
+        if "input_embeds" in kwargs:
+            kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+        if "cache_position" in kwargs and "position_ids" not in kwargs:
+            kwargs["position_ids"] = kwargs.pop("cache_position").unsqueeze(0)
+        else:
+            kwargs.pop("cache_position", None)
+        return kwargs
+
+    def create_causal_mask(**kwargs):  # noqa: F811
+        return _create_causal_mask_v4(**_adapt_mask_kwargs(kwargs))
+    create_causal_mask._v5_shim = True
+
+    def create_sliding_window_causal_mask(**kwargs):  # noqa: F811
+        return _create_sliding_v4(**_adapt_mask_kwargs(kwargs))
+    create_sliding_window_causal_mask._v5_shim = True
+# --- end shim ---------------------------------------------------------------
+"""
+
+POSITION_SLICE = """        # transformers >=5 compat (patched locally): generate grows position_ids
+        # across decode steps, so a cached step receives the FULL history while
+        # inputs_embeds carries only the current token. Slice to the current
+        # step or the rotary broadcast inflates the attention output.
+        if (
+            position_ids is not None
+            and inputs_embeds is not None
+            and position_ids.shape[-1] != inputs_embeds.shape[1]
+        ):
+            position_ids = position_ids[..., -inputs_embeds.shape[1] :]
+
+"""
+
+
+def insert_after_import(s: str, shim: str, import_line: str) -> str:
+    """Insert `shim` after the line matching `import_line`."""
+    assert import_line in s, f"import line not found: {import_line[:60]}"
+    i = s.index(import_line)
+    eol = s.index("\n", i)
+    return s[: eol + 1] + shim + s[eol + 1 :]
+
+
+def insert_after_paren_import(s: str, shim: str, start_line: str) -> str:
+    """Insert `shim` after the closing paren of a parenthesized import."""
+    assert start_line in s, f"paren import start not found: {start_line[:60]}"
+    i = s.index(start_line)
+    close = s.index(")", i)
+    eol = s.index("\n", close)
+    return s[: eol + 1] + shim + s[eol + 1 :]
+
+
+def apply_to_modeling(path: Path) -> bool:
+    s = path.read_text()
+    if "transformers >=5 compat" in s:
+        return False
+
+    # ROPE shim: after the single-line rope import.
+    s = insert_after_import(s, ROPE_SHIM, "from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update")
+
+    # MASK shim: after the parenthesized masking import.
+    s = insert_after_paren_import(s, MASK_SHIM, "from transformers.masking_utils import (")
+
+    # POSITION slice.
+    anchor1 = "        # the hard coded `3` is for temporal, height and width.\n"
+    if anchor1 in s:
+        s = s.replace(anchor1, POSITION_SLICE + anchor1, 1)
+    else:
+        anchor2 = "        if position_ids is None:\n            position_ids = cache_position.unsqueeze(0)\n"
+        assert anchor2 in s, f"{path.name}: no position anchor"
+        s = s.replace(anchor2, POSITION_SLICE + anchor2, 1)
+
+    path.write_text(s)
+    return True
+
+
+def patch_config(path: Path) -> bool:
+    s = path.read_text()
+    if "pad_token_id=None,  # transformers" in s:
+        return False
+    a = "        codec_eos_token_id=4198,\n        codec_think_id=4202,"
+    assert a in s, "config codec_eos anchor"
+    s = s.replace(a, "        codec_eos_token_id=4198,\n        pad_token_id=None,  # transformers >=5 compat; defaults to codec_eos\n        codec_think_id=4202,", 1)
+    a = "        self.codec_eos_token_id = codec_eos_token_id\n        self.codec_think_id = codec_think_id"
+    assert a in s, "config assign anchor"
+    s = s.replace(a, "        self.codec_eos_token_id = codec_eos_token_id\n        self.pad_token_id = pad_token_id if pad_token_id is not None else codec_eos_token_id\n        self.codec_think_id = codec_think_id", 1)
+    path.write_text(s)
+    return True
+
+
+def patch_tokenizer_decorator(path: Path) -> bool:
+    s = path.read_text()
+    a = "from transformers.utils.generic import check_model_inputs"
+    if a in s:
+        s = s.replace(a, "# " + a + "  # dead on transformers >=5 (needs a func arg); unused", 1)
+    d = "    @check_model_inputs()"
+    if d in s:
+        s = s.replace(d, "    # " + d.strip() + "  # dead decorator, unused", 1)
+    path.write_text(s)
+    return True
+
+
+def main() -> None:
+    for f in MODELING_FILES:
+        print(f"{f.name}:", "patched" if apply_to_modeling(f) else "already patched")
+        if f.name == "modeling_qwen3_tts_tokenizer_v2.py":
+            print(f"{f.name}: decorator", "patched" if patch_tokenizer_decorator(f) else "already ok")
+    cfg = REPO / "qwen_tts" / "core" / "models" / "configuration_qwen3_tts.py"
+    print(f"{cfg.name}:", "patched" if patch_config(cfg) else "already patched")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The vendored Qwen3-TTS code is written against transformers 4.x. On a transformers 5 install it loads but **generates garbage audio** (or fails to load at all): transformers 5 removed `ROPE_INIT_FUNCTIONS['default']`, renamed `create_causal_mask`'s args (`input_embeds` -> `inputs_embeds`, dropped `cache_position`), requires `pad_token_id` on the talker config, changed the dead `@check_model_inputs()` decorator's signature, and grows `position_ids` across decode steps (which inflates the mrope broadcast against the single-token embeddings).

All fixes are **conditional and no-op on transformers < 5**, so the existing transformers 4.57.3 path is unchanged. transformers >= 5 is now supported.

## Changes

- **RoPE**: restore `ROPE_INIT_FUNCTIONS['default']` in both `modeling_qwen3_tts.py` files
- **create_causal_mask**: adapt the v4 arg names to v5's (`inputs_embeds`, no `cache_position`)
- **pad_token_id**: default `Qwen3TTSTalkerConfig.pad_token_id` to `codec_eos_token_id` (v5's generate requires it)
- **dead decorator**: comment out `@check_model_inputs()` (v5 signature differs; it is unused)
- **position_ids**: slice to the current step in the decode forwards so the rotary broadcast stays 1:1 with the single-token embeddings
- **RoPE meta-device fixup** (`qwen_tts/_transformers5_fixup.py`): transformers 5 initializes the model on the meta device, so the vendored `Qwen3TTSTalkerRotaryEmbedding` computes an all-zero `inv_freq` whose `original_inv_freq` stays a meta reference; every `dynamic_frequency_update` then re-applies it and generation diverges (163 s runaway, never EOS). `from_pretrained` is wrapped to recompute both buffers on the real device. **This is the primary fix** — without it the shims alone still leave generation unstable (random duration, broken audio tails). The wrapper also repairs the **code-predictor (subtalker) rotary** (`Qwen3TTSRotaryEmbedding`, a separate instance with the same meta-device bug) — unfixed, every decode step's codec tokens differ from transformers 4 even under greedy decoding, which is what made the voices sound off rather than just divergent.
- **sampling defaults** (`nodes.py`): the nodes defaulted to `top_p=0.8/top_k=20/temperature=1.0`, which made the decoder's tail unstable for some seeds (energy dropouts = "broken tail"). Switched to the model's own `generate_config.json` defaults (`top_p=1.0/top_k=50/temperature=0.9`); tails now decay smoothly to silence.
- **clone instruct** (`qwen_tts_model.py`, `nodes.py`): `generate_voice_clone` gains an optional `instruct` passed through as `instruct_ids`, and `FB_Qwen3TTSVoiceClone` exposes it. Same base voice + different instruct = distinct emotion/style delivery while keeping timbre (verified: neutral/angry/happy on one reference differ clearly in f0 and spectral centroid).
- **requirements.txt**: drop the `<5.0.0` cap
- **tools/transformers5_shim.py**: re-applicable, idempotent patch script for fresh installs

## Verification

`VoiceDesignNode` generates clean speech on **transformers 5.14.1** (torch 2.8.0+cu128, RTX 5090) for freeform zh/en instructions; `VoiceCloneNode` clones a reference and speaks with the requested emotion; tails decay cleanly:

```
transformers 5.14.1:  VoiceDesign clean (lag1 0.95+, rms 0.04-0.09), tail monotonic to silence
transformers 4.57.3:  unchanged (shims are no-ops)
```

Without the RoPE fixup on transformers 5, the same call runs away (163 s, no EOS) or stops early with broken tails — the upstream #258 runaway.

## Core findings (debugging deep-dive)

### 1. meta-device RoPE is the primary cause of runaway (not the `ROPE_INIT_FUNCTIONS` KeyError)

The initial shim only fixed the `KeyError: 'default'`, yet generation still diverged (163 s, never EOS). Comparing transformers 4.57.3 / 5.14.1 layer-by-layer pinpointed the real root cause:

- transformers 5 initializes the model on the **meta device**. The vendored `Qwen3TTSTalkerRotaryEmbedding.__init__` runs `rope_init_fn` on meta, yielding an **all-zero `inv_freq`**;
- worse, `self.original_inv_freq = self.inv_freq` keeps a reference to the **meta tensor**, which stays meta after the model materializes to cuda;
- every forward's `dynamic_frequency_update` re-applies the meta `original_inv_freq` over the real buffer → `cos/sin` go to zero → attention loses positional information → generation diverges.

**Evidence** (same VoiceDesign model after load):

| Metric | transformers 4 | transformers 5 |
|---|---|---|
| `inv_freq[:6]` | `[1.0, 0.805, 0.649, ...]` | `[0.0, 0.0, 0.0, ...]` |
| `original_inv_freq.is_meta` | `False` | **`True`** |

**Fix**: recompute `inv_freq` + `original_inv_freq` on the real device after `from_pretrained`. Clone went from a 163 s loop to 3.1 s clean speech; design from 0.86 s (too short) to 4.8 s normal.

### 2. Sampling defaults caused the "broken tail" (independent of the transformers version)

With RoPE fixed, a tail jitter remained (energy dropouts and recovery at the end of the sentence, perceived as "broken"). Per-parameter comparison:

- Node defaults `top_p=0.8, top_k=20, temperature=1.0` (aggressive) → unstable tail codec for some seeds
- Model `generate_config.json` defaults `top_p=1.0, top_k=50, temperature=0.9` → tail decays smoothly to silence

Both defaults behave the same on transformers 4, so this is a default-value choice, not a version regression. Switching to the model defaults cleans the tail.

### 3. The code-predictor (subtalker) rotary was unfixed (same meta-device bug)

With the talker fixed, output was stable but the timbre still differed from transformers 4. Isolating torch (both runs use torch 2.8, separate code dirs) showed prefill is **bit-identical across all 28 layers**, but the first decode step's hidden state already diverged. Root cause:

- `modeling_qwen3_tts.py` has **two** rotary classes: `Qwen3TTSTalkerRotaryEmbedding` (talker) and `Qwen3TTSRotaryEmbedding` (the **code_predictor / subtalker**, used at line 1044).
- The subtalker rotary had the same meta-device all-zero `inv_freq`, so the subtalker's `code_predictor.generate` produced wrong logits every decode step → different codec tokens than transformers 4 even with `subtalker_dosample=False` (greedy).
- After also repairing it, the subtalker's greedy tokens align with v4 for the first tokens, and the final audio matches much more closely:

| Metric | v4 | v5 before | v5 after |
|---|---|---|---|
| duration (s, seed 7) | 3.36 | random (5.58 etc.) | **3.36** |
| median f0 (Hz) | 282 | 324 / 296 | **282** |
| spectral centroid (Hz) | 2900 | 2443 / 2799 | 2595 |

**Lesson**: a model can carry multiple independent rotary/parameter instances; a meta-device fixup must cover all of them.

### Appendix: measured data

```
transformers 5.14.1 + torch 2.8.0+cu128 (RTX 5090):
  VoiceDesign  4.8 s clean, f0 ~270 Hz, tail monotonic
  VoiceClone   x-vector + instruct=angry  f0 258/304 Hz, shorter, brighter
               x-vector + instruct=happy  f0 247/264 Hz, brighter centroid
  transformers 4.57.3  unchanged (all shims no-op)
```

## Note

This is a follow-up to QwenLM/Qwen3-TTS#237 — the official package's `pyproject.toml` pins transformers 4.57.3, but its tokenizer code imports v5-era APIs (`check_model_inputs`, `FlashAttentionKwargs`, `Unpack`), which is why the ecosystem is split. These shims make the ComfyUI nodes work on the increasingly-default transformers 5 without breaking the pinned 4.x path.
